### PR TITLE
Provide named exports for utils

### DIFF
--- a/packages/client/.npmignore
+++ b/packages/client/.npmignore
@@ -29,6 +29,8 @@
 /yarn-error.log
 /yarn.lock
 .gitkeep
+tsconfig.js
+jsconfig.js
 
 # ember-try
 /.node_modules.ember-try/

--- a/packages/client/addon/errors/graphql-client-error.ts
+++ b/packages/client/addon/errors/graphql-client-error.ts
@@ -10,7 +10,7 @@ export interface GraphQLClientErrorRecord {
   locations?: { line: number; column: number }[];
 }
 
-export default class GraphQLClientError extends Error {
+export class GraphQLClientError extends Error {
   response: GraphQLResponse;
   request: GraphQLRequestContext;
   errors: GraphQLClientErrorRecord[];
@@ -34,3 +34,5 @@ export default class GraphQLClientError extends Error {
     return this.errors;
   }
 }
+
+export default GraphQLClientError;

--- a/packages/client/addon/services/graphql.ts
+++ b/packages/client/addon/services/graphql.ts
@@ -240,6 +240,8 @@ export default class GraphQLService extends Service {
   }
 }
 
+export { GraphQLClient } from 'graphql-request';
+
 // DO NOT DELETE: this is how TypeScript knows how to look up your services.
 declare module '@ember/service' {
   interface Registry {

--- a/packages/client/addon/utils/graphql-cache.ts
+++ b/packages/client/addon/utils/graphql-cache.ts
@@ -1,6 +1,6 @@
 import { QueryOptions } from '@ember-graphql-client/client/utils/graphql-request-client';
 
-export default class GraphQLCache {
+export class GraphQLCache {
   _entityCacheMap = new Map();
 
   getCache(entityName: string, entityId?: string): GraphQLEntityCache {
@@ -52,6 +52,8 @@ export class GraphQLEntityCache {
     this._queryCacheMap.delete(hash);
   }
 }
+
+export default GraphQLCache;
 
 // Based on: https://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
 function hashOptions(options: QueryOptions): number {

--- a/packages/client/addon/utils/graphql-request-client.ts
+++ b/packages/client/addon/utils/graphql-request-client.ts
@@ -21,9 +21,7 @@ export interface GraphQLRequestClientInterface {
   mutate(options: MutationOptions): Promise<any>;
 }
 
-export default class GraphQLRequestClient
-  implements GraphQLRequestClientInterface
-{
+export class GraphQLRequestClient implements GraphQLRequestClientInterface {
   client: GraphQLClient;
 
   constructor(client: GraphQLClient) {
@@ -64,3 +62,5 @@ export default class GraphQLRequestClient
     return waitForPromise(promise);
   }
 }
+
+export default GraphQLRequestClient;

--- a/packages/mock/.npmignore
+++ b/packages/mock/.npmignore
@@ -29,6 +29,8 @@
 /yarn-error.log
 /yarn.lock
 .gitkeep
+tsconfig.js
+jsconfig.js
 
 # ember-try
 /.node_modules.ember-try/


### PR DESCRIPTION
Also re-export GraphQLClient for custom usage in your app.