### PR TITLE
feat: Handle non-200 errors

### DIFF
--- a/packages/client/addon/errors/graphql-client-error.ts
+++ b/packages/client/addon/errors/graphql-client-error.ts
@@ -1,13 +1,15 @@
 import { ClientError } from 'graphql-request';
 import type {
+  GraphQLError,
   GraphQLRequestContext,
   GraphQLResponse,
 } from 'graphql-request/dist/types';
 
-export interface GraphQLClientErrorRecord {
+export interface GraphQLClientErrorRecord extends GraphQLError {
   message: string;
   extensions?: any;
-  locations?: { line: number; column: number }[];
+  locations: { line: number; column: number }[];
+  path: string[];
 }
 
 export class GraphQLClientError extends Error {
@@ -21,12 +23,26 @@ export class GraphQLClientError extends Error {
 
     super(message);
 
-    let { errors } = response;
+    // E.g. when a 404 or 50x error happens, the HTML body of the response will be in `error` of `response`.
+    let { errors, error: errorMessage, status } = response;
+
+    if (!errors && errorMessage) {
+      errors = [
+        {
+          message: errorMessage,
+          locations: [],
+          path: [],
+          extensions: {
+            IS_PLAIN_ERROR: true,
+          },
+        },
+      ] as GraphQLClientErrorRecord[];
+    }
 
     this.errors = errors || [];
     this.response = response;
     this.request = request;
-    this.httpStatus = response.status;
+    this.httpStatus = status;
     this.stack = stack;
   }
 

--- a/packages/client/addon/errors/network-error.ts
+++ b/packages/client/addon/errors/network-error.ts
@@ -1,5 +1,7 @@
-export default class GraphQLNetworkError extends Error {
+export class GraphQLNetworkError extends Error {
   constructor() {
     super('A network error occurred');
   }
 }
+
+export default GraphQLNetworkError;

--- a/packages/client/addon/services/graphql.ts
+++ b/packages/client/addon/services/graphql.ts
@@ -216,7 +216,7 @@ export default class GraphQLService extends Service {
       }
     }
 
-    // Network error
+    // Network error, e.g. offline
     if (isNetworkError(error)) {
       return new GraphQLNetworkError();
     }


### PR DESCRIPTION
E.g. when encountering a 404 or 50x error, we now return a "normal" GraphQLClientError with an `errors` property.

You can distinguish it via the `IS_PLAIN_ERROR` extension.