### PR TITLE
fix: Ensure it runs before ember-cli-babel

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -95,6 +95,7 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": "ember-cli-babel"
   }
 }


### PR DESCRIPTION
Otherwise, the converted .graphql files may not be converted properly by babel.